### PR TITLE
Change config for Code Climate test reporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
-machine:
-  environment:  
-    CC_TEST_REPORTER_ID: 8a731d38e836a895f196159fd5a7ca8b1c84fd2f778f0256bcbcf6ff03fbcd1a
 
 jobs:
   build:
+    environment:  
+      CC_TEST_REPORTER_ID: a8fab361c54d385e2546963e7c0fec083fe1920b9e520ce86dd31f0971a11ffe
+
     docker:
       # specify the version you desire here
       - image: circleci/node:9.4.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     environment:  
       CC_TEST_REPORTER_ID: a8fab361c54d385e2546963e7c0fec083fe1920b9e520ce86dd31f0971a11ffe
-
+    
     docker:
       # specify the version you desire here
       - image: circleci/node:9.4.0
@@ -26,6 +26,7 @@ jobs:
           - v1-dependencies-
 
       - run: yarn install --dev
+         
 
       - save_cache:
           paths:
@@ -44,8 +45,7 @@ jobs:
           command: |
             ./cc-test-reporter before-build
             yarn lint && yarn test
-            cd coverage
-            ../cc-test-reporter after-build --debug -t lcov --exit-code $?
+            ./cc-test-reporter after-build --debug -t lcov --exit-code $?
   
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
             ./cc-test-reporter before-build
             yarn lint && yarn test
             cd coverage
-            ../cc-test-reporter after-build --debug -t clover --exit-code $?
+            ../cc-test-reporter after-build --debug -t lcov --exit-code $?
   
 
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "reporter": [
       "clover",
       "html",
-      "text"
+      "text",
+      "lcov"
     ],
     "sourceMap": false,
     "instrument": false


### PR DESCRIPTION
Hi Aneil -

I have a [working solution](https://circleci.com/gh/efueger/markdown-components/31)! You may have a more elegant solution, but here's what I did:

In the config.yml:
- move the CC_TEST_REPORTER to the build step
- removed the command to `cd coverage`
- changed the type indicator (-t) in the `after-build` command to be `lcov` (instead of `clover`)

in the package.json:
- add "lcov" to the reporter

Note: you'll need to keep your CC_TEST_REPORTER as 8a731d38e836a895f196159fd5a7ca8b1c84fd2f778f0256bcbcf6ff03fbcd1a

